### PR TITLE
Adding README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+oauth-sign
+==========
+
+OAuth 1 signing. Formerly a vendor lib in mikeal/request, now a standalone module. 


### PR DESCRIPTION
Adding simple README.md.
That removes warning `No README.md file found!` while installing this package via NPM.
Especially, while installing `request` package, that use that library.
