### PR TITLE
Add support for PLAINTEXT signature method

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,15 @@ function rsasign (httpMethod, base_uri, params, private_key, token_secret) {
   return rsa(key, base)
 }
 
+function plaintext (httpMethod, base_uri, params, consumer_secret, token_secret) {
+  var key = [
+    consumer_secret || '',
+    token_secret || ''
+  ].map(rfc3986).join('&')
+
+  return key
+}
+
 function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_secret) {
   var method
 
@@ -103,6 +112,9 @@ function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_
     case 'HMAC-SHA1':
       method = hmacsign
       break
+    case 'PLAINTEXT':
+      method = plaintext
+      break
     default:
      throw new Error("Signature method not supported: " + signMethod)
   }
@@ -112,5 +124,6 @@ function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_
 
 exports.hmacsign = hmacsign
 exports.rsasign = rsasign
+exports.plaintext = plaintext
 exports.sign = sign
 exports.rfc3986 = rfc3986

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function rsasign (httpMethod, base_uri, params, private_key, token_secret) {
   return rsa(key, base)
 }
 
-function plaintext (httpMethod, base_uri, params, consumer_secret, token_secret) {
+function plaintext (consumer_secret, token_secret) {
   var key = [
     consumer_secret || '',
     token_secret || ''
@@ -104,6 +104,7 @@ function plaintext (httpMethod, base_uri, params, consumer_secret, token_secret)
 
 function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_secret) {
   var method
+  var skipArgs = 1
 
   switch (signMethod) {
     case 'RSA-SHA1':
@@ -114,12 +115,13 @@ function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_
       break
     case 'PLAINTEXT':
       method = plaintext
+      skipArgs = 4
       break
     default:
      throw new Error("Signature method not supported: " + signMethod)
   }
 
-  return method.apply(null, [].slice.call(arguments, 1))
+  return method.apply(null, [].slice.call(arguments, skipArgs))
 }
 
 exports.hmacsign = hmacsign

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
-var hmacsign = require('./index').hmacsign
+var oauth = require('./index')
+  , hmacsign = oauth.hmacsign
   , assert = require('assert')
   , qs = require('querystring')
   ;
@@ -61,3 +62,13 @@ console.log(rfc5849sign)
 console.log('r6/TJjbCOr97/+UU0NsvSne7s5g=')
 assert.equal(rfc5849sign, 'r6/TJjbCOr97/+UU0NsvSne7s5g=')
 
+
+// PLAINTEXT
+
+var plainSign = oauth.sign('PLAINTEXT', 'GET', 'http://dummy.com', {}, 'consumer_secret', 'token_secret')
+console.log(plainSign)
+assert.equal(plainSign, 'consumer_secret&token_secret')
+
+plainSign = oauth.plaintext('consumer_secret', 'token_secret')
+console.log(plainSign)
+assert.equal(plainSign, 'consumer_secret&token_secret')


### PR DESCRIPTION
I was trying to authenticate to Freshbooks using _request_, and it turned out that they currently support **only** `PLAINTEXT` as a signature method http://developers.freshbooks.com/authentication-2/

So I read about it here http://oauth.net/core/1.0/#anchor22 and I figured that it should be the same as the `hmacsign` minus the base string.

Now obviously the first 3 arguments are not needed in this case, but I kept them here because I just pointed my request's oauth-sign dependency to my patched version and it **worked**

I can remove these 3 arguments and after this is being published I can patch the request's source code as well, or we can just leave it as it is. Let me know what do you think.

Also summoning @nylen 