### PR TITLE
Specify license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "oauth-sign",
   "description": "OAuth 1 signing. Formerly a vendor lib in mikeal/request, now a standalone module.",
   "version": "0.6.1",
+  "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/mikeal/oauth-sign"
   },
@@ -15,6 +16,5 @@
   },
   "scripts": {
     "test": "node test.js"
-  },
-  "license": "Apache 2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   },
   "scripts": {
     "test": "node test.js"
-  }
+  },
+  "license": "Apache 2.0"
 }


### PR DESCRIPTION
Hey there,

We're using an automated tool called License Finder (https://github.com/pivotal/LicenseFinder) and your node module comes up as "Unknown". By adding the license to package.json you would help immensely users of this and other automated tools to figure out whether a module can be used inside another project.

Thanks!