### PR TITLE
Handle objects as query params.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ function map (obj) {
     if (Array.isArray(val))
       for (var i = 0; i < val.length; i++)
         arr.push([key, val[i]])
+    else if (typeof val === "object")
+      for (var prop in val)
+        arr.push([key + '[' + prop + ']', val[prop]]);
     else
       arr.push([key, val])
   }

--- a/test.js
+++ b/test.js
@@ -47,6 +47,21 @@ console.log(upsign)
 console.log('yOahq5m0YjDDjfjxHaXEsW9D+X0=')
 assert.equal(upsign, 'yOahq5m0YjDDjfjxHaXEsW9D+X0=')
 
+// handle objects in params (useful for Wordpress REST API)
+var upsign = hmacsign('POST', 'http://wordpress.com/wp-json',
+  { oauth_consumer_key: "GDdmIQH6jhtmLUypg82g"
+  , oauth_nonce: "oElnnMTQIZvqvlfXM56aBLAf5noGD0AQR3Fmi7Q6Y"
+  , oauth_signature_method: "HMAC-SHA1"
+  , oauth_token: "819797-Jxq8aYUDRmykzVKrgoLhXSq67TEa5ruc4GJC2rWimw"
+  , oauth_timestamp: "1272325550"
+  , oauth_version: "1.0"
+  , filter: { number: "-1" }
+  }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "J6zix3FfA9LofH0awS24M3HcBYXO5nI1iYe8EfBA")
+
+console.log(upsign)
+console.log('YrJFBdwnjuIitGpKrxLUplcuuUQ=')
+assert.equal(upsign, 'YrJFBdwnjuIitGpKrxLUplcuuUQ=')
+
 // example in rfc5849
 var params = qs.parse('b5=%3D%253D&a3=a&c%40=&a2=r%20b' + '&' + 'c2&a3=2+q')
 params.oauth_consumer_key = '9djdj82h48djs9d2'


### PR DESCRIPTION
This fixes issue #11, making it so that object params are now properly serialized. This is necessary for interacting with the Wordpress REST API, which uses OAuth v1.0a and also object params.