### PR TITLE
Added support for HMAC-SHA256

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@ oauth-sign
 ==========
 
 OAuth 1 signing. Formerly a vendor lib in mikeal/request, now a standalone module. 
+
+## Supported Method Signatures
+
+- HMAC-SHA1
+- HMAC-SHA256
+- RSA-SHA1
+- PLAINTEXT

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ var crypto = require('crypto')
   , qs = require('querystring')
   ;
 
-function sha1 (key, body) {
-  return crypto.createHmac('sha1', key).update(body).digest('base64')
+function sha (key, body, algorithm) {
+  return crypto.createHmac(algorithm, key).update(body).digest('base64')
 }
 
 function rsa (key, body) {
@@ -86,7 +86,17 @@ function hmacsign (httpMethod, base_uri, params, consumer_secret, token_secret) 
     token_secret || ''
   ].map(rfc3986).join('&')
 
-  return sha1(key, base)
+  return sha(key, base, 'sha1')
+}
+
+function hmacsign256 (httpMethod, base_uri, params, consumer_secret, token_secret) {
+  var base = generateBase(httpMethod, base_uri, params)
+  var key = [
+    consumer_secret || '',
+    token_secret || ''
+  ].map(rfc3986).join('&')
+
+  return sha(key, base, 'sha256')
 }
 
 function rsasign (httpMethod, base_uri, params, private_key, token_secret) {
@@ -116,6 +126,9 @@ function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_
     case 'HMAC-SHA1':
       method = hmacsign
       break
+    case 'HMAC-SHA256':
+      method = hmacsign256
+      break;
     case 'PLAINTEXT':
       method = plaintext
       skipArgs = 4
@@ -128,9 +141,9 @@ function sign (signMethod, httpMethod, base_uri, params, consumer_secret, token_
 }
 
 exports.hmacsign = hmacsign
+exports.hmacsign256 = hmacsign256
 exports.rsasign = rsasign
 exports.plaintext = plaintext
 exports.sign = sign
 exports.rfc3986 = rfc3986
 exports.generateBase = generateBase
-

--- a/test.js
+++ b/test.js
@@ -1,11 +1,89 @@
 var oauth = require('./index')
   , hmacsign = oauth.hmacsign
+  , hmacsign256 = oauth.hmacsign256
   , assert = require('assert')
   , qs = require('querystring')
   ;
 
 // Tests from Twitter documentation https://dev.twitter.com/docs/auth/oauth
+//===============================================================================================
+// HMAC-SHA256 Tests
+//===============================================================================================
 
+var reqsign256 = hmacsign256('POST', 'https://api.twitter.com/oauth/request_token', 
+  { oauth_callback: 'http://localhost:3005/the_dance/process_callback?service_provider_id=11'
+  , oauth_consumer_key: 'GDdmIQH6jhtmLUypg82g'
+  , oauth_nonce: 'QP70eNmVz8jvdPevU3oJD2AfF7R7odC2XJcn4XlZJqk'
+  , oauth_signature_method: 'HMAC-SHA256'
+  , oauth_timestamp: '1272323042'
+  , oauth_version: '1.0'
+  }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98")
+
+console.log(reqsign256)
+console.log('N0KBpiPbuPIMx2B77eIg7tNfGNF81iq3bcO9RO6lH+k=')
+assert.equal(reqsign256, 'N0KBpiPbuPIMx2B77eIg7tNfGNF81iq3bcO9RO6lH+k=')
+
+var accsign256 = hmacsign256('POST', 'https://api.twitter.com/oauth/access_token',
+  { oauth_consumer_key: 'GDdmIQH6jhtmLUypg82g'
+  , oauth_nonce: '9zWH6qe0qG7Lc1telCn7FhUbLyVdjEaL3MO5uHxn8'
+  , oauth_signature_method: 'HMAC-SHA256'
+  , oauth_token: '8ldIZyxQeVrFZXFOZH5tAwj6vzJYuLQpl0WUEYtWc'
+  , oauth_timestamp: '1272323047'
+  , oauth_verifier: 'pDNg57prOHapMbhv25RNf75lVRd6JDsni1AJJIDYoTY'
+  , oauth_version: '1.0'
+  }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "x6qpRnlEmW9JbQn4PQVVeVG8ZLPEx6A0TOebgwcuA")
+  
+console.log(accsign256)
+console.log('y7S9eUhA0tC9/YfRzCPqkg3/bUdYRDpZ93Xi51AvhjQ=')
+assert.equal(accsign256, 'y7S9eUhA0tC9/YfRzCPqkg3/bUdYRDpZ93Xi51AvhjQ=')
+
+var upsign256 = hmacsign256('POST', 'http://api.twitter.com/1/statuses/update.json', 
+  { oauth_consumer_key: "GDdmIQH6jhtmLUypg82g"
+  , oauth_nonce: "oElnnMTQIZvqvlfXM56aBLAf5noGD0AQR3Fmi7Q6Y"
+  , oauth_signature_method: "HMAC-SHA256"
+  , oauth_token: "819797-Jxq8aYUDRmykzVKrgoLhXSq67TEa5ruc4GJC2rWimw"
+  , oauth_timestamp: "1272325550"
+  , oauth_version: "1.0"
+  , status: 'setting up my twitter 私のさえずりを設定する'
+  }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "J6zix3FfA9LofH0awS24M3HcBYXO5nI1iYe8EfBA")
+
+console.log(upsign256)
+console.log('xYhKjozxc3NYef7C26WU+gORdhEURdZRxSDzRttEKH0=')
+assert.equal(upsign256, 'xYhKjozxc3NYef7C26WU+gORdhEURdZRxSDzRttEKH0=')
+
+// handle objects in params (useful for Wordpress REST API)
+var upsign256 = hmacsign256('POST', 'http://wordpress.com/wp-json',
+  { oauth_consumer_key: "GDdmIQH6jhtmLUypg82g"
+  , oauth_nonce: "oElnnMTQIZvqvlfXM56aBLAf5noGD0AQR3Fmi7Q6Y"
+  , oauth_signature_method: "HMAC-SHA256"
+  , oauth_token: "819797-Jxq8aYUDRmykzVKrgoLhXSq67TEa5ruc4GJC2rWimw"
+  , oauth_timestamp: "1272325550"
+  , oauth_version: "1.0"
+  , filter: { number: "-1" }
+  }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "J6zix3FfA9LofH0awS24M3HcBYXO5nI1iYe8EfBA")
+
+console.log(upsign256)
+console.log('6hXbe84vZjenN4Il6ko0dpIBxUXrWj4SBFoBwgCIK+8=')
+assert.equal(upsign256, '6hXbe84vZjenN4Il6ko0dpIBxUXrWj4SBFoBwgCIK+8=')
+
+// example in rfc5849
+var params256 = qs.parse('b5=%3D%253D&a3=a&c%40=&a2=r%20b' + '&' + 'c2&a3=2+q')
+params256.oauth_consumer_key = '9djdj82h48djs9d2'
+params256.oauth_token = 'kkk9d7dh3k39sjv7'
+params256.oauth_nonce = '7d8f3e4a'
+params256.oauth_signature_method = 'HMAC-SHA256'
+params256.oauth_timestamp = '137131201'
+
+var rfc5849sign256 = hmacsign256('POST', 'http://example.com/request',
+  params256, "j49sk3j29djd", "dh893hdasih9")
+
+console.log(rfc5849sign256)
+console.log('ypAxjNip++Dm0fTM+gCl8wAo6ufSnseu1WHxL7py3BU=')
+assert.equal(rfc5849sign256, 'ypAxjNip++Dm0fTM+gCl8wAo6ufSnseu1WHxL7py3BU=')
+
+//===============================================================================================
+// HMAC-SHA1 Tests
+//===============================================================================================
 var reqsign = hmacsign('POST', 'https://api.twitter.com/oauth/request_token', 
   { oauth_callback: 'http://localhost:3005/the_dance/process_callback?service_provider_id=11'
   , oauth_consumer_key: 'GDdmIQH6jhtmLUypg82g'
@@ -77,9 +155,9 @@ console.log(rfc5849sign)
 console.log('r6/TJjbCOr97/+UU0NsvSne7s5g=')
 assert.equal(rfc5849sign, 'r6/TJjbCOr97/+UU0NsvSne7s5g=')
 
-
-// PLAINTEXT
-
+//===============================================================================================
+// PLAINTEXT Tests
+//===============================================================================================
 var plainSign = oauth.sign('PLAINTEXT', 'GET', 'http://dummy.com', {}, 'consumer_secret', 'token_secret')
 console.log(plainSign)
 assert.equal(plainSign, 'consumer_secret&token_secret')


### PR DESCRIPTION
Added support for HMAC-256.
Added tests for HMAC-256.
Updated readme to show what signatures are supported.

This is being done to add the industry accepted HMAC-SHA256 to OAuth1.0. While not officially part of the spec it is commonly supported.