### PR TITLE
exclude default port according to RFC5894 section-3.4.1.2

### DIFF
--- a/test.js
+++ b/test.js
@@ -28,10 +28,24 @@ var accsign = hmacsign('POST', 'https://api.twitter.com/oauth/access_token',
   , oauth_verifier: 'pDNg57prOHapMbhv25RNf75lVRd6JDsni1AJJIDYoTY'
   , oauth_version: '1.0'
   }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "x6qpRnlEmW9JbQn4PQVVeVG8ZLPEx6A0TOebgwcuA")
-  
+
 console.log(accsign)
 console.log('PUw/dHA4fnlJYM6RhXk5IU/0fCc=')
 assert.equal(accsign, 'PUw/dHA4fnlJYM6RhXk5IU/0fCc=')
+
+var accsign2 = hmacsign('POST', 'https://api.twitter.com:443/oauth/access_token',
+{ oauth_consumer_key: 'GDdmIQH6jhtmLUypg82g'
+, oauth_nonce: '9zWH6qe0qG7Lc1telCn7FhUbLyVdjEaL3MO5uHxn8'
+, oauth_signature_method: 'HMAC-SHA1'
+, oauth_token: '8ldIZyxQeVrFZXFOZH5tAwj6vzJYuLQpl0WUEYtWc'
+, oauth_timestamp: '1272323047'
+, oauth_verifier: 'pDNg57prOHapMbhv25RNf75lVRd6JDsni1AJJIDYoTY'
+, oauth_version: '1.0'
+}, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "x6qpRnlEmW9JbQn4PQVVeVG8ZLPEx6A0TOebgwcuA")
+
+console.log(accsign2)
+console.log('PUw/dHA4fnlJYM6RhXk5IU/0fCc=')
+assert.equal(accsign2, 'PUw/dHA4fnlJYM6RhXk5IU/0fCc=')
 
 var upsign = hmacsign('POST', 'http://api.twitter.com/1/statuses/update.json', 
   { oauth_consumer_key: "GDdmIQH6jhtmLUypg82g"
@@ -46,6 +60,20 @@ var upsign = hmacsign('POST', 'http://api.twitter.com/1/statuses/update.json',
 console.log(upsign)
 console.log('yOahq5m0YjDDjfjxHaXEsW9D+X0=')
 assert.equal(upsign, 'yOahq5m0YjDDjfjxHaXEsW9D+X0=')
+
+var upsign2 = hmacsign('POST', 'http://api.twitter.com:80/1/statuses/update.json', 
+  { oauth_consumer_key: "GDdmIQH6jhtmLUypg82g"
+  , oauth_nonce: "oElnnMTQIZvqvlfXM56aBLAf5noGD0AQR3Fmi7Q6Y"
+  , oauth_signature_method: "HMAC-SHA1"
+  , oauth_token: "819797-Jxq8aYUDRmykzVKrgoLhXSq67TEa5ruc4GJC2rWimw"
+  , oauth_timestamp: "1272325550"
+  , oauth_version: "1.0"
+  , status: 'setting up my twitter 私のさえずりを設定する'
+  }, "MCD8BKwGdgPHvAuvgvz4EQpqDAtx89grbuNMRd7Eh98", "J6zix3FfA9LofH0awS24M3HcBYXO5nI1iYe8EfBA")
+
+console.log(upsign2)
+console.log('yOahq5m0YjDDjfjxHaXEsW9D+X0=')
+assert.equal(upsign2, 'yOahq5m0YjDDjfjxHaXEsW9D+X0=')
 
 // handle objects in params (useful for Wordpress REST API)
 var upsign = hmacsign('POST', 'http://wordpress.com/wp-json',


### PR DESCRIPTION
According to RFC5894 section 3.4.1.2

"3.  The port MUST be included if it is not the default port for the
       scheme, and MUST be excluded if it is the default.  Specifically,
       the port MUST be excluded when making an HTTP request [RFC2616]
       to port 80 or when making an HTTPS request [RFC2818] to port 443.
       All other non-default port numbers MUST be included."

The port 80 for http and port 443 for https should be excluded.
